### PR TITLE
EZP-31232: Fixed invalid licence entry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "Behat",
     "Allure"
   ],
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "authors": [
     {
       "name": "Eduard Sukharev",


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31232

Content from the email from Packagist:
```
The ezsystems/allure-behat package of which you are a maintainer has
failed to update due to invalid data contained in your composer.json.
Please address this as soon as possible since the package stopped updating.

It is recommended that you use `composer validate` to check for errors when you
change your composer.json.

Below is the full update log which should highlight errors as
"Skipped branch ...":

[Composer\Repository\InvalidRepositoryException]: Some branches contained invalid data and were discarded, it is advised to review the log and fix any issues present in branches

Reading composer.json of ezsystems/allure-behat (v3.0.0)
Found cached composer.json of ezsystems/allure-behat (v3.0.0)
Reading composer.json of ezsystems/allure-behat (v2.0.0)
Found cached composer.json of ezsystems/allure-behat (v2.0.0)
Reading composer.json of ezsystems/allure-behat (1.1.0)
Found cached composer.json of ezsystems/allure-behat (1.1.0)
Reading composer.json of ezsystems/allure-behat (1.0.3)
Found cached composer.json of ezsystems/allure-behat (1.0.3)
Reading composer.json of ezsystems/allure-behat (1.0.2)
Found cached composer.json of ezsystems/allure-behat (1.0.2)
Reading composer.json of ezsystems/allure-behat (1.0.1)
Found cached composer.json of ezsystems/allure-behat (1.0.1)
Reading composer.json of ezsystems/allure-behat (1.0.0)
Found cached composer.json of ezsystems/allure-behat (1.0.0)
Reading composer.json of ezsystems/allure-behat (EZP-31227)
Importing branch EZP-31227 (dev-EZP-31227)
Skipped branch EZP-31227, Invalid package information: 
License "Apache 2.0" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.

Reading composer.json of ezsystems/allure-behat (master)
Found cached composer.json of ezsystems/allure-behat (dev-master)
Reading composer.json of ezsystems/allure-behat (2.0)
Importing branch 2.0 (2.0.x-dev)
Skipped branch 2.0, Invalid package information: 
License "Apache 2.0" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.

Reading composer.json of ezsystems/allure-behat (3.0)
Importing branch 3.0 (3.0.x-dev)
Skipped branch 3.0, Invalid package information: 
License "Apache 2.0" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```

According to https://spdx.org/licenses/ the identifier for Apache 2.0 is `Apache-2.0`. The licence (and identifier) came from the original repository - https://github.com/allure-framework/allure-behat/blob/master/composer.json#L9 (which appears to be abadonded by creators).

# Testing:

## Before:
```
MBP-Marek:allure-behat mareknocon$ composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
Defining autoload.psr-0 with an empty namespace prefix is a bad idea for performance
License "Apache 2.0" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```

## After:
```
MBP-Marek:allure-behat mareknocon$ composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
Defining autoload.psr-0 with an empty namespace prefix is a bad idea for performance
```

The licence warning is gone. The PSR-0 warning is something that we can tackle later (and maybe consider switching to PSR-4).

*Note:* The other Allure repository already uses the correct identifier: https://github.com/ezsystems/allure-php-commons/blob/2.0/composer.json#L6