### PR TITLE
Added checking if severity_key is defined before using it

### DIFF
--- a/src/Allure/Behat/Formatter/AllureFormatter.php
+++ b/src/Allure/Behat/Formatter/AllureFormatter.php
@@ -373,7 +373,7 @@ class AllureFormatter implements Formatter
         }
       }
 
-      if (stripos($tag, $this->severity_key) === 0) {
+      if ($this->severity_key && stripos($tag, $this->severity_key) === 0) {
         $level = preg_replace("/$this->severity_key/", '', $tag);
         try {
           $level = ConstantChecker::validate('Yandex\Allure\Adapter\Model\SeverityLevel', $level);


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31227

Making sure that `severity_key` is defined before using it is enough to get rid of the PHP warning.