### PR TITLE
EZP-31453: Added basic CI setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+composer.lock
+composer.phar

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,9 @@
+<?php
+
+use EzSystems\EzPlatformCodeStyle\PhpCsFixer\Config;
+
+return Config::create()
+          ->setFinder(PhpCsFixer\Finder::create()
+            ->in(__DIR__ . '/src')
+            ->files()->name('*.php')
+    );

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,77 @@
+dist: trusty
+language: php
+php:
+  - 7.3
+
+env:
+  global:
+    - EZPLATFORM_REPO="https://github.com/ezsystems/ezplatform.git"
+    - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
+    - SYMFONY_ENV=behat
+    - SYMFONY_DEBUG=1
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+# test only master and stable branches (+ Pull requests)
+branches:
+  only:
+    - master
+    - /^\d+\.\d+$/
+
+jobs:
+  include:
+    - name: "Code Style Check"
+      env: CHECK_CS=1
+    - name: "Unit tests"
+      env: PHPUNIT_CONFIG='phpunit.xml'
+    - name: "Allure Behat tests"
+      php: 7.3
+      env: RUN_ALLURE_BEHAT=1
+    - name: "AdminUI Modules tests"
+      php: 7.3
+      env:
+        -BEHAT_OPTS="--mode=standard --profile=adminui --suite=adminuimodules"
+
+git:
+  depth: 30
+
+notifications:
+  slack:
+    rooms:
+      - secure: "ATZ8+miq/+/OnPKNBPrj4aDYLdH1+rVp3RGOeJ5r7vxa8TGQVCG65ABDvXJA5vJZy/Nq2y8o/LbCXt+qkWQOGdidHiI+RAOZs1WyNHnWlAEl32+9+63o1JJiZFXs4LBC/68sn+6UwQCZd5N+RkHch64tZ+MCVQUEuzetysMXC1H5K1vrQofonOMITXqBPkFyUrYj+f6EwvfkmrNAKyDx8CJFgvM9GekJnGDORpCP8UKEd7Uj9KEvu6SD65RB6B+Deb+YTyESN+zlqdqYAZ9ocz0RFj51UeAMl99IGnxG3Lpvagj9OX1VqAYKYmdCXiCK6I90Gs5eSbPqUaHYfRgA8EPZIP0miQRIKx1/hi/NtmFwy9cUVaPBfPcNB2Z/Bigtm9rgfNpthjo184bh+bnPiPKps8rXrnGNGpEOLp9B9rs+yu52UynMETzAYBLVCQw/wzhW7Bcx+19hh+m2m7s2Js+XTlTh0RNspOoj1zT0PP17+SecVtUGodnOzF05t7i2qzj34VSIiFL5Ri7d6llUY7OVeIkxorx6Xkm5FrVTeMpOZBNXogBKfOsWsusUwT3wDVY/w3h/aykbQlehEDsIqg6FaFUBGoMuqPTtXj8PSX+XuZ+P/tD6vCsElwgjOmNiFAs+PxJl2oFckVw9IfqeLv5PPuEIbWAI0ut9GFxnTAs="
+    on_success: change
+    on_failure: always
+    on_pull_requests: false
+
+before_install:
+  # Disable XDebug for performance
+  - phpenv config-rm xdebug.ini
+  # Get latest composer build
+  - travis_retry composer selfupdate
+  # Avoid memory issues on composer install
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
+install:
+  # Install packages if needed
+  - if [ "${CHECK_CS}" == "1" -o "${PHPUNIT_CONFIG}" != "" -o "${RUN_ALLURE_BEHAT}" == "1" ]; then travis_retry composer install --prefer-dist --no-interaction --no-suggest ; fi
+  # Prepare whole environment if needed
+  - if [ "${BEHAT_OPTS}" != "" ]; then ./bin/.travis/prepare_ezplatform.sh ; fi
+
+script:
+  - if [ "${CHECK_CS}" == "1" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --show-progress=estimating ; fi
+  - if [ "${PHPUNIT_CONFIG}" != '' ]; then ./vendor/bin/phpunit -c "${PHPUNIT_CONFIG}"; fi
+  - if [ "${RUN_ALLURE_BEHAT}" != '' ]; then ./vendor/behat/behat/bin/behat; fi
+  - if [ "${BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/ezbehat $BEHAT_OPTS" ; fi
+
+after_failure:
+  # Will show us the last bit of the log of container's main processes
+  # (not counting shell process above running php and behat)
+  # NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
+  - docker-compose logs -t --tail=15
+  # Will show us what is up, and how long it's been up
+  - docker ps -s
+
+after_script:
+  - if [ "${BEHAT_OPTS}" != "" ] ; then bin/ezreport; fi

--- a/bin/.travis/prepare_ezplatform.sh
+++ b/bin/.travis/prepare_ezplatform.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+EZPLATFORM_BRANCH=`php -r 'echo json_decode(file_get_contents("./composer.json"))->extra->_ezplatform_branch_for_behat_tests;'`
+EZPLATFORM_BRANCH="${EZPLATFORM_BRANCH:-master}"
+PACKAGE_BUILD_DIR=$PWD
+EZPLATFORM_BUILD_DIR=${HOME}/build/ezplatform
+
+echo "> Cloning ezsystems/ezplatform:${EZPLATFORM_BRANCH}"
+git clone --depth 1 --single-branch  --branch "${EZPLATFORM_BRANCH}" ${EZPLATFORM_REPO} ${EZPLATFORM_BUILD_DIR}
+cd ${EZPLATFORM_BUILD_DIR}
+
+/bin/bash ./bin/.travis/trusty/setup_ezplatform.sh "${COMPOSE_FILE}" '' "${PACKAGE_BUILD_DIR}"

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,29 @@
     }
   ],
   "require": {
-    "php": ">=5.5",
+    "php": "^7.1",
     "behat/behat": "^3.3",
     "ezsystems/allure-php-api": "^2.0"
   },
   "require-dev": {
+    "ezsystems/ezplatform-code-style": "^0.1.0",
+    "friendsofphp/php-cs-fixer": "^2.16.0",
     "symfony/process": "~2.5|~3.0|~4.0",
-    "phpunit/phpunit": "^4.8.36|^6.3"
+    "phpunit/phpunit": "^7.0"
   },
   "autoload": {
     "psr-0": {
       "": "src/"
     }
+  },
+  "scripts": {
+    "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+  },
+  "extra": {
+      "_ezplatform_branch_for_behat_tests": "2.5",
+      "branch-alias": {
+          "dev-master": "2.0.x-dev",
+          "dev-tmp_ci_branch": "2.0.x-dev"
+      }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<phpunit
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        bootstrap="vendor/autoload.php"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        colors="true">
+    <testsuites>
+        <testsuite name="EzSystems\BehatBundle">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Allure/Behat/AllureFormatterExtension.php
+++ b/src/Allure/Behat/AllureFormatterExtension.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Copyright (c) 2016 Eduard Sukharev
- * Copyright (c) 2018 Tiko Lakin
+ * Copyright (c) 2018 Tiko Lakin.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
  *
  * See LICENSE.md for full license text.
  */
-
 namespace Allure\Behat;
 
 use Behat\Testwork\Exception\ServiceContainer\ExceptionExtension;
@@ -28,78 +27,73 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-
 class AllureFormatterExtension implements ExtensionInterface
 {
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+    }
 
-  /**
-   * You can modify the container here before it is dumped to PHP code.
-   *
-   * @param ContainerBuilder $container
-   */
-  public function process(ContainerBuilder $container)
-  {
+    /**
+     * Returns the extension config key.
+     *
+     * @return string
+     */
+    public function getConfigKey()
+    {
+        return 'allure';
+    }
 
-  }
+    /**
+     * Initializes other extensions.
+     *
+     * This method is called immediately after all extensions are activated but
+     * before any extension `configure()` method is called. This allows extensions
+     * to hook into the configuration of other extensions providing such an
+     * extension point.
+     *
+     * @param ExtensionManager $extensionManager
+     */
+    public function initialize(ExtensionManager $extensionManager)
+    {
+    }
 
-  /**
-   * Returns the extension config key.
-   *
-   * @return string
-   */
-  public function getConfigKey()
-  {
-    return 'allure';
-  }
+    /**
+     * Setups configuration for the extension.
+     *
+     * @param ArrayNodeDefinition $builder
+     */
+    public function configure(ArrayNodeDefinition $builder)
+    {
+        $builder->children()->scalarNode('name')->defaultValue('allure');
+        $builder->children()->scalarNode('issue_tag_prefix')->defaultValue(null);
+        $builder->children()->scalarNode('test_id_tag_prefix')->defaultValue(null);
+        $builder->children()->scalarNode('ignored_tags')->defaultValue(null);
+        $builder->children()->scalarNode('severity_key')->defaultValue(null);
+    }
 
-  /**
-   * Initializes other extensions.
-   *
-   * This method is called immediately after all extensions are activated but
-   * before any extension `configure()` method is called. This allows extensions
-   * to hook into the configuration of other extensions providing such an
-   * extension point.
-   *
-   * @param ExtensionManager $extensionManager
-   */
-  public function initialize(ExtensionManager $extensionManager)
-  {
-
-  }
-
-  /**
-   * Setups configuration for the extension.
-   *
-   * @param ArrayNodeDefinition $builder
-   */
-  public function configure(ArrayNodeDefinition $builder)
-  {
-    $builder->children()->scalarNode("name")->defaultValue('allure');
-    $builder->children()->scalarNode("issue_tag_prefix")->defaultValue(null);
-    $builder->children()->scalarNode("test_id_tag_prefix")->defaultValue(null);
-    $builder->children()->scalarNode("ignored_tags")->defaultValue(null);
-    $builder->children()->scalarNode("severity_key")->defaultValue(null);
-  }
-
-  /**
-   * Loads extension services into temporary container.
-   *
-   * @param ContainerBuilder $container
-   * @param array $config
-   */
-  public function load(ContainerBuilder $container, array $config)
-  {
-    $definition = new Definition("Allure\\Behat\\Formatter\\AllureFormatter");
-    $definition->addArgument($config['name']);
-    $definition->addArgument($config['issue_tag_prefix']);
-    $definition->addArgument($config['test_id_tag_prefix']);
-    $definition->addArgument($config['ignored_tags']);
-    $definition->addArgument($config['severity_key']);
-    $definition->addArgument('%paths.base%');
-    $presenter = new Reference(ExceptionExtension::PRESENTER_ID);
-    $definition->addArgument($presenter);
-    $container->setDefinition("allure.formatter", $definition)
-      ->addTag("output.formatter");
-  }
-
+    /**
+     * Loads extension services into temporary container.
+     *
+     * @param ContainerBuilder $container
+     * @param array $config
+     */
+    public function load(ContainerBuilder $container, array $config)
+    {
+        $definition = new Definition('Allure\\Behat\\Formatter\\AllureFormatter');
+        $definition->addArgument($config['name']);
+        $definition->addArgument($config['issue_tag_prefix']);
+        $definition->addArgument($config['test_id_tag_prefix']);
+        $definition->addArgument($config['ignored_tags']);
+        $definition->addArgument($config['severity_key']);
+        $definition->addArgument('%paths.base%');
+        $presenter = new Reference(ExceptionExtension::PRESENTER_ID);
+        $definition->addArgument($presenter);
+        $container->setDefinition('allure.formatter', $definition)
+      ->addTag('output.formatter');
+    }
 }

--- a/src/Allure/Behat/Exception/ArtifactExceptionInterface.php
+++ b/src/Allure/Behat/Exception/ArtifactExceptionInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2018 Tiko Lakin
+ * Copyright (c) 2018 Tiko Lakin.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,27 +20,27 @@ namespace Allure\Behat\Exception;
 
 interface ArtifactExceptionInterface
 {
+    /**
+     * ArtifactExceptionInterface constructor.
+     *
+     * @param $message
+     * @param \Behat\Mink\Driver\CoreDriver $driver
+     * @param \Exception $previous
+     */
+    public function __construct($message, \Behat\Mink\Driver\CoreDriver $driver, \Exception $previous = null);
 
-  /**
-   * ArtifactExceptionInterface constructor.
-   * @param $message
-   * @param \Behat\Mink\Driver\CoreDriver $driver
-   * @param \Exception $previous
-   */
-  public function __construct($message, \Behat\Mink\Driver\CoreDriver $driver, \Exception $previous = null);
+    /**
+     * @return string|void
+     */
+    public function getUrl();
 
-  /**
-   * @return string|void
-   */
-  public function getUrl();
+    /**
+     * @return string|void
+     */
+    public function getScreenPath();
 
-  /**
-   * @return string|void
-   */
-  public function getScreenPath();
-
-  /**
-   * @return string|void
-   */
-  public function getHtmlPath();
+    /**
+     * @return string|void
+     */
+    public function getHtmlPath();
 }

--- a/src/Allure/Behat/Formatter/AllureFormatter.php
+++ b/src/Allure/Behat/Formatter/AllureFormatter.php
@@ -245,7 +245,8 @@ class AllureFormatter implements Formatter
     );
 
     $annotationManager = new AnnotationManager($annotations);
-    $scenarioName = sprintf('%s:%d', $feature->getFile(), $scenario->getLine());
+    $scenarioFilePath = str_replace($this->base_path . '/', '', $feature->getFile());
+    $scenarioName = sprintf('%s:%d', $scenarioFilePath, $scenario->getLine());
     $scenarioEvent = new TestCaseStartedEvent($this->uuid, $scenarioName);
     $annotationManager->updateTestCaseEvent($scenarioEvent);
 

--- a/src/Allure/Behat/Formatter/AllureFormatter.php
+++ b/src/Allure/Behat/Formatter/AllureFormatter.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Copyright (c) 2016 Eduard Sukharev
- * Copyright (c) 2018 Tiko Lakin
+ * Copyright (c) 2018 Tiko Lakin.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
  *
  * See LICENSE.md for full license text.
  */
-
 namespace Allure\Behat\Formatter;
 
 use Allure\Behat\Exception\ArtifactExceptionInterface;
@@ -71,218 +70,214 @@ use Yandex\Allure\Adapter\Support\AttachmentSupport;
 
 class AllureFormatter implements Formatter
 {
+    protected $output;
+    protected $name;
+    protected $base_path;
+    protected $timer;
+    protected $exception;
+    protected $attachment = [];
+    protected $uuid;
+    protected $issueTagPrefix;
+    protected $testIdTagPrefix;
+    protected $ignoredTags;
+    protected $severity_key;
+    protected $parameters;
+    protected $printer;
+    protected $outlineCounter = 0;
 
-  protected $output;
-  protected $name;
-  protected $base_path;
-  protected $timer;
-  protected $exception;
-  protected $attachment = [];
-  protected $uuid;
-  protected $issueTagPrefix;
-  protected $testIdTagPrefix;
-  protected $ignoredTags;
-  protected $severity_key;
-  protected $parameters;
-  protected $printer;
-  protected $outlineCounter = 0;
+    /** @var \Behat\Testwork\Exception\ExceptionPresenter */
+    protected $presenter;
 
-  /** @var  \Behat\Testwork\Exception\ExceptionPresenter */
-  protected $presenter;
+    /** @var Allure */
+    private $lifecycle;
 
-  /** @var  Allure */
-  private $lifecycle;
+    private $scopeAnnotation = [];
 
-  private $scopeAnnotation = [];
+    use AttachmentSupport;
 
-  use AttachmentSupport;
-
-  public function __construct($name, $issue_tag_prefix, $test_id_tag_prefix, $ignoredTags, $severity_key, $base_path, $presenter)
-  {
-    $this->name = $name;
-    $this->issueTagPrefix = $issue_tag_prefix;
-    $this->testIdTagPrefix = $test_id_tag_prefix;
-    $this->ignoredTags = $ignoredTags;
-    $this->severity_key = $severity_key;
-    $this->base_path = $base_path;
-    $this->presenter = $presenter;
-    $this->timer = new Timer();
-    $this->printer = new DummyOutputPrinter();
-    $this->parameters = new ParameterBag();
-  }
-
-  private function getLifeCycle()
-  {
-    if (!isset($this->lifecycle)) {
-      $this->lifecycle = Allure::lifecycle();
+    public function __construct($name, $issue_tag_prefix, $test_id_tag_prefix, $ignoredTags, $severity_key, $base_path, $presenter)
+    {
+        $this->name = $name;
+        $this->issueTagPrefix = $issue_tag_prefix;
+        $this->testIdTagPrefix = $test_id_tag_prefix;
+        $this->ignoredTags = $ignoredTags;
+        $this->severity_key = $severity_key;
+        $this->base_path = $base_path;
+        $this->presenter = $presenter;
+        $this->timer = new Timer();
+        $this->printer = new DummyOutputPrinter();
+        $this->parameters = new ParameterBag();
     }
-    return $this->lifecycle;
-  }
 
-  /**
-   * Returns an array of event names this subscriber wants to listen to.
-   *
-   * The array keys are event names and the value can be:
-   *
-   *  * The method name to call (priority defaults to 0)
-   *  * An array composed of the method name to call and the priority
-   *  * An array of arrays composed of the method names to call and respective
-   *    priorities, or 0 if unset
-   *
-   * For instance:
-   *
-   *  * array('eventName' => 'methodName')
-   *  * array('eventName' => array('methodName', $priority))
-   *  * array('eventName' => array(array('methodName1', $priority),
-   * array('methodName2')))
-   *
-   * @return array The event names to listen to
-   */
-  public static function getSubscribedEvents()
-  {
-    return array(
+    private function getLifeCycle()
+    {
+        if (!isset($this->lifecycle)) {
+            $this->lifecycle = Allure::lifecycle();
+        }
+
+        return $this->lifecycle;
+    }
+
+    /**
+     * Returns an array of event names this subscriber wants to listen to.
+     *
+     * The array keys are event names and the value can be:
+     *
+     *  * The method name to call (priority defaults to 0)
+     *  * An array composed of the method name to call and the priority
+     *  * An array of arrays composed of the method names to call and respective
+     *    priorities, or 0 if unset
+     *
+     * For instance:
+     *
+     *  * array('eventName' => 'methodName')
+     *  * array('eventName' => array('methodName', $priority))
+     *  * array('eventName' => array(array('methodName1', $priority),
+     * array('methodName2')))
+     *
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
       SuiteTested::BEFORE => 'onBeforeSuiteTested',
       SuiteTested::AFTER => 'onAfterSuiteTested',
       ScenarioTested::BEFORE => 'onBeforeScenarioTested',
       ScenarioTested::AFTER => 'onAfterScenarioTested',
       StepTested::BEFORE => 'onBeforeStepTested',
-      StepTested::AFTER  => 'onAfterStepTested',
+      StepTested::AFTER => 'onAfterStepTested',
       ExampleTested::BEFORE => 'onBeforeScenarioTested',
       ExampleTested::AFTER => 'onAfterScenarioTested',
-    );
+    ];
+    }
 
-  }
+    /**
+     * Returns formatter name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
 
-  /**
-   * Returns formatter name.
-   *
-   * @return string
-   */
-  public function getName()
-  {
-    return $this->name;
-  }
+    /**
+     * Returns formatter description.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Allure formatter for Behat 3';
+    }
 
-  /**
-   * Returns formatter description.
-   *
-   * @return string
-   */
-  public function getDescription()
-  {
-    return "Allure formatter for Behat 3";
-  }
+    /**
+     * Returns formatter output printer.
+     *
+     * @return OutputPrinter
+     */
+    public function getOutputPrinter()
+    {
+        return $this->printer;
+    }
 
-  /**
-   * Returns formatter output printer.
-   *
-   * @return OutputPrinter
-   */
-  public function getOutputPrinter()
-  {
-    return $this->printer;
-  }
+    /**
+     * Sets formatter parameter.
+     *
+     * @param string $name
+     * @param mixed $value
+     */
+    public function setParameter($name, $value)
+    {
+        $this->parameters->set($name, $value);
+    }
 
-  /**
-   * Sets formatter parameter.
-   *
-   * @param string $name
-   * @param mixed $value
-   */
-  public function setParameter($name, $value)
-  {
-    $this->parameters->set($name, $value);
-  }
+    /**
+     * Returns parameter name.
+     *
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function getParameter($name)
+    {
+        return $this->parameters->get($name);
+    }
 
-  /**
-   * Returns parameter name.
-   *
-   * @param string $name
-   *
-   * @return mixed
-   */
-  public function getParameter($name)
-  {
-    return $this->parameters->get($name);
-  }
-
-  public function onBeforeSuiteTested(BeforeSuiteTested $event)
-  {
-
-    AnnotationProvider::addIgnoredAnnotations([]);
-    $this->prepareOutputDirectory(
+    public function onBeforeSuiteTested(BeforeSuiteTested $event)
+    {
+        AnnotationProvider::addIgnoredAnnotations([]);
+        $this->prepareOutputDirectory(
       $this->printer->getOutputPath()
     );
-    $start_event = new TestSuiteStartedEvent($event->getSuite()->getName());
+        $start_event = new TestSuiteStartedEvent($event->getSuite()->getName());
 
-    $this->uuid = $start_event->getUuid();
+        $this->uuid = $start_event->getUuid();
 
-    $this->getLifeCycle()->fire($start_event);
-  }
+        $this->getLifeCycle()->fire($start_event);
+    }
 
-  public function onAfterSuiteTested(AfterSuiteTested $event)
-  {
-    AnnotationProvider::registerAnnotationNamespaces();
-    $this->getLifeCycle()->fire(new TestSuiteFinishedEvent($this->uuid));
+    public function onAfterSuiteTested(AfterSuiteTested $event)
+    {
+        AnnotationProvider::registerAnnotationNamespaces();
+        $this->getLifeCycle()->fire(new TestSuiteFinishedEvent($this->uuid));
+    }
 
-  }
+    public function onBeforeScenarioTested(BeforeScenarioTested $event)
+    {
+        /** @var \Behat\Gherkin\Node\ScenarioNode $scenario */
+        $scenario = $event->getScenario();
+        /** @var \Behat\Gherkin\Node\FeatureNode $feature */
+        $feature = $event->getFeature();
 
-  public function onBeforeScenarioTested(BeforeScenarioTested $event)
-  {
-    /** @var \Behat\Gherkin\Node\ScenarioNode $scenario */
-    $scenario = $event->getScenario();
-    /** @var \Behat\Gherkin\Node\FeatureNode $feature */
-    $feature = $event->getFeature();
+        $isExample = $scenario instanceof ExampleNode;
 
-    $isExample = $scenario instanceof ExampleNode;
+        $exampleAnnotations = ($isExample) ? $this->parseExampleAnnotations($scenario->getTokens()) : [];
 
-    $exampleAnnotations = ($isExample) ? $this->parseExampleAnnotations($scenario->getTokens()) : [];
-
-    $annotations = array_merge(
+        $annotations = array_merge(
       $this->parseFeatureAnnotations($feature),
       $this->parseScenarioAnnotations($scenario),
       $exampleAnnotations
     );
 
-    $annotationManager = new AnnotationManager($annotations);
-    $scenarioFilePath = str_replace($this->base_path . '/', '', $feature->getFile());
-    $scenarioName = sprintf('%s:%d', $scenarioFilePath, $scenario->getLine());
-    $scenarioEvent = new TestCaseStartedEvent($this->uuid, $scenarioName);
-    $annotationManager->updateTestCaseEvent($scenarioEvent);
+        $annotationManager = new AnnotationManager($annotations);
+        $scenarioFilePath = str_replace($this->base_path . '/', '', $feature->getFile());
+        $scenarioName = sprintf('%s:%d', $scenarioFilePath, $scenario->getLine());
+        $scenarioEvent = new TestCaseStartedEvent($this->uuid, $scenarioName);
+        $annotationManager->updateTestCaseEvent($scenarioEvent);
 
-    $scenarioTitle = ($isExample) ? $scenario->getOutlineTitle() : $scenario->getTitle();
+        $scenarioTitle = ($isExample) ? $scenario->getOutlineTitle() : $scenario->getTitle();
 
-    $this->getLifeCycle()->fire($scenarioEvent->withTitle($scenarioTitle));
-
-  }
-
-  public function onAfterScenarioTested(AfterScenarioTested $event)
-  {
-    $this->processScenarioResult($event->getTestResult());
-  }
-
-  public function onBeforeStepTested(BeforeStepTested $event)
-  {
-    $step = $event->getStep();
-    $stepEvent = new StepStartedEvent($step->getText());
-    $stepEvent->withTitle(sprintf('%s %s', $step->getType(), $step->getText()));
-
-    $this->getLifeCycle()->fire($stepEvent);
-  }
-
-  public function onAfterStepTested(AfterStepTested $event)
-  {
-    $result = $event->getTestResult();
-
-    if ($result instanceof ExceptionResult && $result->hasException()) {
-      $this->exception = $result->getException();
-      if ($this->exception instanceof ArtifactExceptionInterface) {
-        $this->attachment[md5_file($this->exception->getScreenPath())] = $this->exception->getScreenPath();
-        $this->attachment[md5_file($this->exception->getHtmlPath())] = $this->exception->getHtmlPath();
-      }
+        $this->getLifeCycle()->fire($scenarioEvent->withTitle($scenarioTitle));
     }
 
-    switch ($event->getTestResult()->getResultCode()) {
+    public function onAfterScenarioTested(AfterScenarioTested $event)
+    {
+        $this->processScenarioResult($event->getTestResult());
+    }
+
+    public function onBeforeStepTested(BeforeStepTested $event)
+    {
+        $step = $event->getStep();
+        $stepEvent = new StepStartedEvent($step->getText());
+        $stepEvent->withTitle(sprintf('%s %s', $step->getType(), $step->getText()));
+
+        $this->getLifeCycle()->fire($stepEvent);
+    }
+
+    public function onAfterStepTested(AfterStepTested $event)
+    {
+        $result = $event->getTestResult();
+
+        if ($result instanceof ExceptionResult && $result->hasException()) {
+            $this->exception = $result->getException();
+            if ($this->exception instanceof ArtifactExceptionInterface) {
+                $this->attachment[md5_file($this->exception->getScreenPath())] = $this->exception->getScreenPath();
+                $this->attachment[md5_file($this->exception->getHtmlPath())] = $this->exception->getHtmlPath();
+            }
+        }
+
+        switch ($event->getTestResult()->getResultCode()) {
       case StepResult::FAILED:
         $this->addFailedStep();
         break;
@@ -297,119 +292,117 @@ class AllureFormatter implements Formatter
       default:
         $this->exception = new \Exception('Error occurred out of test scope.');
     }
-    $this->addFinishedStep();
-  }
+        $this->addFinishedStep();
+    }
 
-  protected function prepareOutputDirectory($outputDirectory)
-  {
-    if (!file_exists($outputDirectory)) {
-        try {
-            mkdir($outputDirectory, 0755, true);
-        } catch (\ErrorException $ee) {
-            if (!is_dir($outputDirectory)) {
-                throw $ee;
+    protected function prepareOutputDirectory($outputDirectory)
+    {
+        if (!file_exists($outputDirectory)) {
+            try {
+                mkdir($outputDirectory, 0755, true);
+            } catch (\ErrorException $ee) {
+                if (!is_dir($outputDirectory)) {
+                    throw $ee;
+                }
             }
         }
-    }
 
-    if (is_null(Provider::getOutputDirectory())) {
-      Provider::setOutputDirectory($outputDirectory);
-    }
-  }
-
-  protected function parseFeatureAnnotations(FeatureNode $featureNode)
-  {
-    $this->scopeAnnotation = $featureNode->getTags();
-    $description = new Description();
-    $description->type = DescriptionType::TEXT;
-    $description->value = $featureNode->getDescription();
-    return [$this->scopeAnnotation, $description];
-  }
-
-  protected function parseScenarioAnnotations(ScenarioInterface $scenarioNode)
-  {
-
-    $annotations = [];
-
-    $story = new Stories();
-    $story->stories = [];
-
-    $issues = new Issues();
-    $issues->issueKeys = [];
-
-    $testId = new TestCaseId();
-    $testId->testCaseIds = [];
-
-    $severity = new Severity();
-
-    $ignoredTags = [];
-
-    $title = $scenarioNode instanceof ExampleNode ? $scenarioNode->getOutlineTitle() : $scenarioNode->getTitle();
-    //$story->stories[] = $title;
-
-    if (is_string($this->ignoredTags)) {
-      $ignoredTags = array_map('trim', explode(',', $this->ignoredTags));
-    } elseif (is_array($this->ignoredTags)) {
-      $ignoredTags = $ignoredTags;
-    }
-
-    $annotation = array_merge($this->scopeAnnotation, $scenarioNode->getTags());
-    foreach ($annotation as $tag) {
-
-      if (in_array($tag, $ignoredTags)) {
-        continue;
-      }
-
-      if ($this->issueTagPrefix) {
-        if (stripos($tag, $this->issueTagPrefix) === 0) {
-          $issues->issueKeys[] = substr($tag, strlen($this->issueTagPrefix));
-          continue;
+        if (null === Provider::getOutputDirectory()) {
+            Provider::setOutputDirectory($outputDirectory);
         }
-      }
+    }
 
-      if ($this->testIdTagPrefix) {
-        if (stripos($tag, $this->testIdTagPrefix) === 0) {
-          $testId->testCaseIds[] = substr($tag, strlen($this->testIdTagPrefix));
-          continue;
+    protected function parseFeatureAnnotations(FeatureNode $featureNode)
+    {
+        $this->scopeAnnotation = $featureNode->getTags();
+        $description = new Description();
+        $description->type = DescriptionType::TEXT;
+        $description->value = $featureNode->getDescription();
+
+        return [$this->scopeAnnotation, $description];
+    }
+
+    protected function parseScenarioAnnotations(ScenarioInterface $scenarioNode)
+    {
+        $annotations = [];
+
+        $story = new Stories();
+        $story->stories = [];
+
+        $issues = new Issues();
+        $issues->issueKeys = [];
+
+        $testId = new TestCaseId();
+        $testId->testCaseIds = [];
+
+        $severity = new Severity();
+
+        $ignoredTags = [];
+
+        $title = $scenarioNode instanceof ExampleNode ? $scenarioNode->getOutlineTitle() : $scenarioNode->getTitle();
+        //$story->stories[] = $title;
+
+        if (is_string($this->ignoredTags)) {
+            $ignoredTags = array_map('trim', explode(',', $this->ignoredTags));
+        } elseif (is_array($this->ignoredTags)) {
+            $ignoredTags = $ignoredTags;
         }
-      }
 
-      if ($this->severity_key && stripos($tag, $this->severity_key) === 0) {
-        $level = preg_replace("/$this->severity_key/", '', $tag);
-        try {
-          $level = ConstantChecker::validate('Yandex\Allure\Adapter\Model\SeverityLevel', $level);
-          $severity->level = $level;
-        } catch (AllureException $e) {
-          $severity->level = SeverityLevel::NORMAL;
+        $annotation = array_merge($this->scopeAnnotation, $scenarioNode->getTags());
+        foreach ($annotation as $tag) {
+            if (in_array($tag, $ignoredTags)) {
+                continue;
+            }
+
+            if ($this->issueTagPrefix) {
+                if (stripos($tag, $this->issueTagPrefix) === 0) {
+                    $issues->issueKeys[] = substr($tag, strlen($this->issueTagPrefix));
+                    continue;
+                }
+            }
+
+            if ($this->testIdTagPrefix) {
+                if (stripos($tag, $this->testIdTagPrefix) === 0) {
+                    $testId->testCaseIds[] = substr($tag, strlen($this->testIdTagPrefix));
+                    continue;
+                }
+            }
+
+            if ($this->severity_key && stripos($tag, $this->severity_key) === 0) {
+                $level = preg_replace("/$this->severity_key/", '', $tag);
+                try {
+                    $level = ConstantChecker::validate('Yandex\Allure\Adapter\Model\SeverityLevel', $level);
+                    $severity->level = $level;
+                } catch (AllureException $e) {
+                    $severity->level = SeverityLevel::NORMAL;
+                }
+                array_push($annotations, $severity);
+                continue;
+            }
+
+            $story->stories[] = $tag;
         }
-        array_push($annotations, $severity);
-        continue;
-      }
 
-      $story->stories[] = $tag;
+        if ($story->getStories()) {
+            array_push($annotations, $story);
+        }
+        if ($issues->getIssueKeys()) {
+            array_push($annotations, $issues);
+        }
+        if ($testId->getTestCaseIds()) {
+            array_push($annotations, $testId);
+        }
+
+        return $annotations;
     }
 
-    if ($story->getStories()) {
-      array_push($annotations, $story);
-    }
-    if ($issues->getIssueKeys()) {
-      array_push($annotations, $issues);
-    }
-    if ($testId->getTestCaseIds()) {
-      array_push($annotations, $testId);
-    }
-    return $annotations;
+    protected function processScenarioResult($result)
+    {
+        if ($result instanceof ExceptionResult && $result->hasException()) {
+            $this->exception = $result->getException();
+        }
 
-  }
-
-  protected function processScenarioResult($result)
-  {
-
-    if ($result instanceof ExceptionResult && $result->hasException()) {
-      $this->exception = $result->getException();
-    }
-
-    switch ($result->getResultCode()) {
+        switch ($result->getResultCode()) {
       case StepResult::FAILED:
         $this->addTestCaseFailed();
         break;
@@ -425,90 +418,80 @@ class AllureFormatter implements Formatter
       case StepResult::PASSED:
       default:
         $this->exception = new \Exception('Error occurred out of test scope.');
-
     }
-    $this->addTestCaseFinished();
-  }
-
-  protected function parseExampleAnnotations(array $tokens)
-  {
-
-    $parameters = [];
-
-    foreach ($tokens as $name => $value) {
-      $parameter = new Parameter();
-      $parameter->name = $name;
-      $parameter->value = $value;
-      $parameters[] = $parameter;
+        $this->addTestCaseFinished();
     }
 
-    return $parameters;
-  }
+    protected function parseExampleAnnotations(array $tokens)
+    {
+        $parameters = [];
 
-  protected function addAttachments()
-  {
-    array_walk($this->attachment, function ($path, $key) {
-      $this->addAttachment($path, $key . '-attachment');
-    });
-  }
+        foreach ($tokens as $name => $value) {
+            $parameter = new Parameter();
+            $parameter->name = $name;
+            $parameter->value = $value;
+            $parameters[] = $parameter;
+        }
 
-  private function addCancelledStep()
-  {
+        return $parameters;
+    }
 
-    $event = new StepCanceledEvent();
-    $this->getLifeCycle()->fire($event);
-  }
+    protected function addAttachments()
+    {
+        array_walk($this->attachment, function ($path, $key) {
+            $this->addAttachment($path, $key . '-attachment');
+        });
+    }
 
-  private function addFinishedStep()
-  {
+    private function addCancelledStep()
+    {
+        $event = new StepCanceledEvent();
+        $this->getLifeCycle()->fire($event);
+    }
 
-    $event = new StepFinishedEvent();
-    $this->getLifeCycle()->fire($event);
-  }
+    private function addFinishedStep()
+    {
+        $event = new StepFinishedEvent();
+        $this->getLifeCycle()->fire($event);
+    }
 
-  private function addFailedStep()
-  {
+    private function addFailedStep()
+    {
+        $event = new StepFailedEvent();
+        $this->getLifeCycle()->fire($event);
+    }
 
-    $event = new StepFailedEvent();
-    $this->getLifeCycle()->fire($event);
-  }
+    private function addTestCaseFinished()
+    {
+        $event = new TestCaseFinishedEvent();
+        $this->getLifeCycle()->fire($event);
+    }
 
-  private function addTestCaseFinished()
-  {
+    private function addTestCaseCancelled()
+    {
+        $event = new TestCaseCanceledEvent();
+        $this->getLifeCycle()->fire($event);
+    }
 
-    $event = new TestCaseFinishedEvent();
-    $this->getLifeCycle()->fire($event);
-  }
+    private function addTestCasePending()
+    {
+        $event = new TestCasePendingEvent();
+        $this->getLifeCycle()->fire($event);
+    }
 
-  private function addTestCaseCancelled()
-  {
+    private function addTestCaseBroken()
+    {
+        $event = new TestCaseBrokenEvent();
+        $this->getLifeCycle()->fire($event);
+    }
 
-    $event = new TestCaseCanceledEvent();
-    $this->getLifeCycle()->fire($event);
-  }
-
-  private function addTestCasePending()
-  {
-
-    $event = new TestCasePendingEvent();
-    $this->getLifeCycle()->fire($event);
-  }
-
-  private function addTestCaseBroken()
-  {
-
-    $event = new TestCaseBrokenEvent();
-    $this->getLifeCycle()->fire($event);
-  }
-
-  private function addTestCaseFailed()
-  {
-
-    $event = new TestCaseFailedEvent();
-    $event->withException($this->exception)
+    private function addTestCaseFailed()
+    {
+        $event = new TestCaseFailedEvent();
+        $event->withException($this->exception)
       ->withMessage($this->exception->getMessage());
-    $this->addAttachments();
+        $this->addAttachments();
 
-    $this->getLifeCycle()->fire($event);
-  }
+        $this->getLifeCycle()->fire($event);
+    }
 }

--- a/src/Allure/Behat/Printer/DummyOutputPrinter.php
+++ b/src/Allure/Behat/Printer/DummyOutputPrinter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2018 Tiko Lakin
+ * Copyright (c) 2018 Tiko Lakin.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,133 +16,130 @@
  *
  * See LICENSE.md for full license text.
  */
-
 namespace Allure\Behat\Printer;
 
 use Behat\Testwork\Output\Printer\OutputPrinter as PrinterInterface;
 
 class DummyOutputPrinter implements PrinterInterface
 {
+    protected $outputPath = 'allure-results';
+    protected $outputStyles;
+    protected $rendererFiles;
 
-  protected $outputPath = 'allure-results';
-  protected $outputStyles;
-  protected $rendererFiles;
+    /**
+     * Sets output path.
+     *
+     * @param string $path
+     */
+    public function setOutputPath($path)
+    {
+        $this->outputPath = $path;
+    }
 
-  /**
-   * Sets output path.
-   *
-   * @param string $path
-   */
-  public function setOutputPath($path)
-  {
-    $this->outputPath = $path;
-  }
+    /**
+     * Returns output path.
+     *
+     * @return string|null
+     *
+     * @deprecated since 3.1, to be removed in 4.0
+     */
+    public function getOutputPath()
+    {
+        return $this->outputPath;
+    }
 
-  /**
-   * Returns output path.
-   *
-   * @return null|string
-   *
-   * @deprecated since 3.1, to be removed in 4.0
-   */
-  public function getOutputPath()
-  {
-    return $this->outputPath;
-  }
+    /**
+     * Sets output styles.
+     *
+     * @param array $styles
+     */
+    public function setOutputStyles(array $styles)
+    {
+        $this->outputStyles = $styles;
+    }
 
-  /**
-   * Sets output styles.
-   *
-   * @param array $styles
-   */
-  public function setOutputStyles(array $styles)
-  {
-    $this->outputStyles = $styles;
-  }
+    /**
+     * Returns output styles.
+     *
+     * @return array
+     *
+     * @deprecated since 3.1, to be removed in 4.0
+     */
+    public function getOutputStyles()
+    {
+        return $this->outputStyles;
+    }
 
-  /**
-   * Returns output styles.
-   *
-   * @return array
-   *
-   * @deprecated since 3.1, to be removed in 4.0
-   */
-  public function getOutputStyles()
-  {
-    return $this->outputStyles;
-  }
+    /**
+     * Forces output to be decorated.
+     *
+     * @param bool $decorated
+     */
+    public function setOutputDecorated($decorated)
+    {
+        // TODO: Implement setOutputDecorated() method.
+    }
 
-  /**
-   * Forces output to be decorated.
-   *
-   * @param Boolean $decorated
-   */
-  public function setOutputDecorated($decorated)
-  {
-    // TODO: Implement setOutputDecorated() method.
-  }
+    /**
+     * Returns output decoration status.
+     *
+     * @return bool|null
+     *
+     * @deprecated since 3.1, to be removed in 4.0
+     */
+    public function isOutputDecorated()
+    {
+        return true;
+    }
 
-  /**
-   * Returns output decoration status.
-   *
-   * @return null|Boolean
-   *
-   * @deprecated since 3.1, to be removed in 4.0
-   */
-  public function isOutputDecorated()
-  {
-    return TRUE;
-  }
+    /**
+     * Sets output verbosity level.
+     *
+     * @param int $level
+     */
+    public function setOutputVerbosity($level)
+    {
+        // TODO: Implement setOutputVerbosity() method.
+    }
 
-  /**
-   * Sets output verbosity level.
-   *
-   * @param integer $level
-   */
-  public function setOutputVerbosity($level)
-  {
-    // TODO: Implement setOutputVerbosity() method.
-  }
+    /**
+     * Returns output verbosity level.
+     *
+     * @return int
+     *
+     * @deprecated since 3.1, to be removed in 4.0
+     */
+    public function getOutputVerbosity()
+    {
+        // TODO: Implement getOutputVerbosity() method.
+    }
 
-  /**
-   * Returns output verbosity level.
-   *
-   * @return integer
-   *
-   * @deprecated since 3.1, to be removed in 4.0
-   */
-  public function getOutputVerbosity()
-  {
-    // TODO: Implement getOutputVerbosity() method.
-  }
+    /**
+     * Writes message(s) to output stream.
+     *
+     * @param string|array $messages message or array of messages
+     */
+    public function write($messages)
+    {
+        // TODO: Implement write() method.
+    }
 
-  /**
-   * Writes message(s) to output stream.
-   *
-   * @param string|array $messages message or array of messages
-   */
-  public function write($messages)
-  {
-    // TODO: Implement write() method.
-  }
+    /**
+     * Writes newlined message(s) to output stream.
+     *
+     * @param string|array $messages message or array of messages
+     */
+    public function writeln($messages = '')
+    {
+        // TODO: Implement writeln() method.
+    }
 
-  /**
-   * Writes newlined message(s) to output stream.
-   *
-   * @param string|array $messages message or array of messages
-   */
-  public function writeln($messages = '')
-  {
-    // TODO: Implement writeln() method.
-  }
-
-  /**
-   * Clear output stream, so on next write formatter will need to init (create)
-   * it again.
-   */
-  public function flush()
-  {
-    // TODO: Implement flush() method.
-  }
-
+    /**
+     * Clear output stream, so on next write formatter will need to init (create)
+     * it again.
+     */
+    public function flush()
+    {
+        // TODO: Implement flush() method.
+    }
 }


### PR DESCRIPTION
Done as preparation for https://github.com/ezsystems/allure-behat/pull/6, so can be treated as part of https://jira.ez.no/browse/EZP-31453

This PR:
1) Adds basic Travis setup:
a) adds notifications
b) runs eZ Platform Behat tests to make sure the integration is working
c) runs Allure Behat tests to make sure the extension is working as expected (I adjusted the code so that tests are passing)
d) runs code style job (with custom config - we can't change Licence header of existing files)
e) runs unit tests (will be added in https://github.com/ezsystems/allure-behat/pull/6)
2) Runs codestyle job
3) Adds .gitignore file to make development easier

For easier review:
- Setup changes - first commit
- **Second commit contains only codestyle changes**

TODO when merging upstream:
- [ ] Replace SYMFONY_* variables with APP_*
- [ ] Adjust branch aliases in composer.json