### PR TITLE
Add attachments support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,10 @@
   "require": {
     "php": "^7.1",
     "behat/behat": "^3.3",
-    "ezsystems/allure-php-api": "^2.0"
+    "ezsystems/allure-php-api": "^2.0@dev"
   },
   "require-dev": {
+    "bex/behat-screenshot": "^1.2|^2.1",
     "ezsystems/ezplatform-code-style": "^0.1.0",
     "friendsofphp/php-cs-fixer": "^2.16.0",
     "symfony/process": "~2.5|~3.0|~4.0",

--- a/features/allure_formatter.feature
+++ b/features/allure_formatter.feature
@@ -66,7 +66,7 @@ Feature: Allure Formatter
         <name>default</name>
         <test-cases>
           <test-case start="-IGNORE-VALUE-" stop="-IGNORE-VALUE-" status="passed">
-            <name>features/World.feature:8</name>
+            <name>World.feature:8</name>
             <title>Scenario annotation</title>
             <description type="text"><![CDATA[In order to have meta information of the scenario
       As a features developer

--- a/src/Allure/Behat/AllureFormatterExtension.php
+++ b/src/Allure/Behat/AllureFormatterExtension.php
@@ -19,6 +19,10 @@
  */
 namespace Allure\Behat;
 
+use Allure\Behat\Attachment\ScreenshotProvider;
+use Allure\Behat\Attachment\TextAttachmentProvider;
+use Allure\Behat\Formatter\AllureFormatter;
+use Behat\Symfony2Extension\ServiceContainer\Symfony2Extension;
 use Behat\Testwork\Exception\ServiceContainer\ExceptionExtension;
 use Behat\Testwork\ServiceContainer\Extension as ExtensionInterface;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
@@ -26,9 +30,12 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use EzSystems\EzPlatformAdminUi\Behat\Helper\TestLogProvider;
 
 class AllureFormatterExtension implements ExtensionInterface
 {
+    private const SCREENSHOT_UPLOADER_SERVICE_ID = 'bex.screenshot_extension.screenshot_uploader';
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -74,6 +81,7 @@ class AllureFormatterExtension implements ExtensionInterface
         $builder->children()->scalarNode('test_id_tag_prefix')->defaultValue(null);
         $builder->children()->scalarNode('ignored_tags')->defaultValue(null);
         $builder->children()->scalarNode('severity_key')->defaultValue(null);
+        $builder->children()->scalarNode('image_attachment_limit')->defaultValue(10);
     }
 
     /**
@@ -84,16 +92,46 @@ class AllureFormatterExtension implements ExtensionInterface
      */
     public function load(ContainerBuilder $container, array $config)
     {
-        $definition = new Definition('Allure\\Behat\\Formatter\\AllureFormatter');
+        $this->loadFormatter($container, $config);
+
+        if (class_exists(TestLogProvider::class)) {
+            $this->loadTestAttachmentProvider($container);
+        }
+
+        if ($container->has(self::SCREENSHOT_UPLOADER_SERVICE_ID)) {
+            $this->loadScreenshotExtension($container, $config);
+        }
+    }
+
+    private function loadFormatter(ContainerBuilder $container, array $config): void
+    {
+        $definition = new Definition(AllureFormatter::class);
         $definition->addArgument($config['name']);
         $definition->addArgument($config['issue_tag_prefix']);
         $definition->addArgument($config['test_id_tag_prefix']);
         $definition->addArgument($config['ignored_tags']);
         $definition->addArgument($config['severity_key']);
         $definition->addArgument('%paths.base%');
-        $presenter = new Reference(ExceptionExtension::PRESENTER_ID);
-        $definition->addArgument($presenter);
-        $container->setDefinition('allure.formatter', $definition)
-      ->addTag('output.formatter');
+        $definition->addArgument(new Reference(ExceptionExtension::PRESENTER_ID));
+        $container->setDefinition('allure.formatter', $definition)->addTag('output.formatter');
+    }
+
+    private function loadTestAttachmentProvider(ContainerBuilder $containerBuilder)
+    {
+        $definition = new Definition(TextAttachmentProvider::class);
+        $definition->addArgument(new Reference('mink'));
+        $definition->addArgument(new Reference(Symfony2Extension::KERNEL_ID));
+        $definition->addTag('event_dispatcher.subscriber');
+        $containerBuilder->setDefinition(TextAttachmentProvider::class, $definition);
+    }
+
+    private function loadScreenshotExtension(ContainerBuilder $container, array $config)
+    {
+        $container
+        ->register(ScreenshotProvider::class)
+        ->setDecoratedService(self::SCREENSHOT_UPLOADER_SERVICE_ID)
+        ->addArgument(new Reference('bex.screenshot_extension.indented_output'))
+        ->addArgument(new Reference('bex.screenshot_extension.config'))
+        ->addArgument($config['image_attachment_limit']);
     }
 }

--- a/src/Allure/Behat/Attachment/ScreenshotProvider.php
+++ b/src/Allure/Behat/Attachment/ScreenshotProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Allure\Behat\Attachment;
+
+use Bex\Behat\ScreenshotExtension\Service\ScreenshotUploader;
+use Bex\Behat\ScreenshotExtension\ServiceContainer\Config;
+use FilesystemIterator;
+use Symfony\Component\Console\Output\OutputInterface;
+use Yandex\Allure\Adapter\Allure;
+use Yandex\Allure\Adapter\Event\AddAttachmentEvent;
+use Yandex\Allure\Adapter\Model\Provider;
+
+class ScreenshotProvider extends ScreenshotUploader
+{
+    /** @var int */
+    private $screenshotLimit;
+
+    public function __construct(OutputInterface $output, Config $config, int $screenshotLimit)
+    {
+        parent::__construct($output, $config);
+        $this->screenshotLimit = $screenshotLimit;
+    }
+
+    public function upload($screenshot, $fileName = 'failure.png')
+    {
+        parent::upload($screenshot, $fileName);
+
+        if ($this->shouldAddAttachment()) {
+            Allure::lifecycle()->fire(new AddAttachmentEvent($screenshot, 'Browser screenshot'));
+        }
+    }
+
+    private function shouldAddAttachment(): bool
+    {
+        return $this->isOutputDirectoryConfigured() && $this->getNumberOfScreenshotsTaken() < $this->screenshotLimit;
+    }
+
+    private function getNumberOfScreenshotsTaken(): int
+    {
+        $iterator = new \GlobIterator(Provider::getOutputDirectory() . '/*.png', FilesystemIterator::KEY_AS_FILENAME);
+
+        return iterator_count($iterator);
+    }
+
+    private function isOutputDirectoryConfigured(): bool
+    {
+        // PHPStorm uses its own formatter which does not configure Allure output path
+        return Provider::getOutputDirectory() !== null;
+    }
+}

--- a/src/Allure/Behat/Attachment/TextAttachmentProvider.php
+++ b/src/Allure/Behat/Attachment/TextAttachmentProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Allure\Behat\Attachment;
+
+use Behat\Behat\EventDispatcher\Event\AfterStepTested;
+use Behat\Behat\EventDispatcher\Event\StepTested;
+use Behat\Testwork\Tester\Result\TestResult;
+use EzSystems\EzPlatformAdminUi\Behat\Helper\TestLogProvider;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Yandex\Allure\Adapter\Allure;
+use Yandex\Allure\Adapter\Event\AddAttachmentEvent;
+use Behat\Mink\Mink;
+use Yandex\Allure\Adapter\Model\Provider;
+
+class TextAttachmentProvider implements EventSubscriberInterface
+{
+    /**
+     * @var \Behat\Mink\Mink
+     */
+    private $mink;
+
+    /**
+     * @var \Symfony\Component\HttpKernel\KernelInterface
+     */
+    private $kernel;
+
+    public function __construct(Mink $mink, KernelInterface $kernel)
+    {
+        $this->mink = $mink;
+        $this->kernel = $kernel;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+          StepTested::AFTER => 'provideLogsOnError',
+        ];
+    }
+
+    public function provideLogsOnError(AfterStepTested $event)
+    {
+        if ($event->getTestResult()->getResultCode() !== TestResult::FAILED) {
+            return;
+        }
+
+        $testLogProvider = new TestLogProvider($this->mink->getSession(), $this->kernel->getLogDir());
+        $applicationsLogs = $testLogProvider->getApplicationLogs();
+        $browserLogs = $testLogProvider->getBrowserLogs();
+
+        if ($this->isOutputDirectoryConfigured()) {
+            Allure::lifecycle()->fire(new AddAttachmentEvent($this->formatForDisplay($browserLogs), 'JS console logs'));
+            Allure::lifecycle()->fire(new AddAttachmentEvent($this->formatForDisplay($applicationsLogs), 'Application logs'));
+        }
+    }
+
+    private function formatForDisplay(array $entries)
+    {
+        return implode(PHP_EOL, $entries);
+    }
+
+    private function isOutputDirectoryConfigured(): bool
+    {
+        // PHPStorm uses its own formatter which does not configure Allure output path
+        return Provider::getOutputDirectory() !== null;
+    }
+}

--- a/src/Allure/Behat/Formatter/AllureFormatter.php
+++ b/src/Allure/Behat/Formatter/AllureFormatter.php
@@ -19,7 +19,6 @@
  */
 namespace Allure\Behat\Formatter;
 
-use Allure\Behat\Exception\ArtifactExceptionInterface;
 use Allure\Behat\Printer\DummyOutputPrinter;
 use Behat\Behat\EventDispatcher\Event\AfterScenarioTested;
 use Behat\Behat\EventDispatcher\Event\AfterStepTested;
@@ -66,7 +65,6 @@ use Yandex\Allure\Adapter\Model\ConstantChecker;
 use Yandex\Allure\Adapter\Model\DescriptionType;
 use Yandex\Allure\Adapter\Model\Provider;
 use Yandex\Allure\Adapter\Model\SeverityLevel;
-use Yandex\Allure\Adapter\Support\AttachmentSupport;
 
 class AllureFormatter implements Formatter
 {
@@ -75,7 +73,6 @@ class AllureFormatter implements Formatter
     protected $base_path;
     protected $timer;
     protected $exception;
-    protected $attachment = [];
     protected $uuid;
     protected $issueTagPrefix;
     protected $testIdTagPrefix;
@@ -92,8 +89,6 @@ class AllureFormatter implements Formatter
     private $lifecycle;
 
     private $scopeAnnotation = [];
-
-    use AttachmentSupport;
 
     public function __construct($name, $issue_tag_prefix, $test_id_tag_prefix, $ignoredTags, $severity_key, $base_path, $presenter)
     {
@@ -207,9 +202,8 @@ class AllureFormatter implements Formatter
     public function onBeforeSuiteTested(BeforeSuiteTested $event)
     {
         AnnotationProvider::addIgnoredAnnotations([]);
-        $this->prepareOutputDirectory(
-      $this->printer->getOutputPath()
-    );
+        $this->prepareOutputDirectory($this->printer->getOutputPath());
+
         $start_event = new TestSuiteStartedEvent($event->getSuite()->getName());
 
         $this->uuid = $start_event->getUuid();
@@ -241,8 +235,7 @@ class AllureFormatter implements Formatter
     );
 
         $annotationManager = new AnnotationManager($annotations);
-        $scenarioFilePath = str_replace($this->base_path . '/', '', $feature->getFile());
-        $scenarioName = sprintf('%s:%d', $scenarioFilePath, $scenario->getLine());
+        $scenarioName = $this->formatScenarioName($feature->getFile(), $scenario->getLine());
         $scenarioEvent = new TestCaseStartedEvent($this->uuid, $scenarioName);
         $annotationManager->updateTestCaseEvent($scenarioEvent);
 
@@ -271,27 +264,21 @@ class AllureFormatter implements Formatter
 
         if ($result instanceof ExceptionResult && $result->hasException()) {
             $this->exception = $result->getException();
-            if ($this->exception instanceof ArtifactExceptionInterface) {
-                $this->attachment[md5_file($this->exception->getScreenPath())] = $this->exception->getScreenPath();
-                $this->attachment[md5_file($this->exception->getHtmlPath())] = $this->exception->getHtmlPath();
-            }
         }
 
-        switch ($event->getTestResult()->getResultCode()) {
-      case StepResult::FAILED:
-        $this->addFailedStep();
-        break;
-      case StepResult::UNDEFINED:
-        $this->addFailedStep();
-        break;
-      case StepResult::PENDING:
-      case StepResult::SKIPPED:
-        $this->addCancelledStep();
-        break;
-      case StepResult::PASSED:
-      default:
-        $this->exception = new \Exception('Error occurred out of test scope.');
-    }
+        switch ($result->getResultCode()) {
+          case StepResult::FAILED:
+          case StepResult::UNDEFINED:
+            $this->addFailedStep();
+            break;
+          case StepResult::PENDING:
+          case StepResult::SKIPPED:
+            $this->addCancelledStep();
+            break;
+          case StepResult::PASSED:
+          default:
+            $this->exception = new \Exception('Error occurred out of test scope.');
+        }
         $this->addFinishedStep();
     }
 
@@ -338,9 +325,6 @@ class AllureFormatter implements Formatter
         $severity = new Severity();
 
         $ignoredTags = [];
-
-        $title = $scenarioNode instanceof ExampleNode ? $scenarioNode->getOutlineTitle() : $scenarioNode->getTitle();
-        //$story->stories[] = $title;
 
         if (is_string($this->ignoredTags)) {
             $ignoredTags = array_map('trim', explode(',', $this->ignoredTags));
@@ -436,13 +420,6 @@ class AllureFormatter implements Formatter
         return $parameters;
     }
 
-    protected function addAttachments()
-    {
-        array_walk($this->attachment, function ($path, $key) {
-            $this->addAttachment($path, $key . '-attachment');
-        });
-    }
-
     private function addCancelledStep()
     {
         $event = new StepCanceledEvent();
@@ -488,10 +465,15 @@ class AllureFormatter implements Formatter
     private function addTestCaseFailed()
     {
         $event = new TestCaseFailedEvent();
-        $event->withException($this->exception)
-      ->withMessage($this->exception->getMessage());
-        $this->addAttachments();
-
+        $event->withException($this->exception)->withMessage($this->exception->getMessage());
         $this->getLifeCycle()->fire($event);
+    }
+
+    private function formatScenarioName(string $fileName, int $lineNumber): string
+    {
+        $parts = explode('/', $fileName);
+        $lastPart = end($parts);
+
+        return sprintf('%s:%d', $lastPart, $lineNumber);
     }
 }

--- a/tests/Attachment/ScreenshotProviderTest.php
+++ b/tests/Attachment/ScreenshotProviderTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Allure\Behat\Test\Attachment;
+
+use Allure\Behat\Attachment\ScreenshotProvider;
+use Bex\Behat\ScreenshotExtension\Service\ScreenshotTaker;
+use Bex\Behat\ScreenshotExtension\Service\ScreenshotUploader;
+use Bex\Behat\ScreenshotExtension\ServiceContainer\Config;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+use Yandex\Allure\Adapter\Allure;
+use Yandex\Allure\Adapter\Event\AddAttachmentEvent;
+use Yandex\Allure\Adapter\Model\Provider;
+
+class ScreenshotProviderTest extends TestCase
+{
+
+  public function testProvidesScreenshotAttachmentWhenConfigured()
+  {
+      // Given
+      $outputInterface = $this
+          ->getMockBuilder(OutputInterface::class)
+          ->disableOriginalConstructor()
+        ->getMock();
+
+      $config = $this
+        ->getMockBuilder(Config::class)
+        ->disableOriginalConstructor()
+        ->getMock();
+
+      $config->expects($this->once())->method('getImageDrivers')->willReturn([]);
+      $screenshotProvider = new ScreenshotProvider($outputInterface, $config, 1);
+      Allure::setDefaultLifecycle();
+      Provider::setOutputDirectory(sys_get_temp_dir());
+
+      // When
+      $screenshotProvider->upload('test');
+
+      // Then
+      Assert::assertInstanceOf(AddAttachmentEvent::class, Allure::lifecycle()->getLastEvent());
+  }
+
+  public function testDoesNothingWhenNotConfigured()
+  {
+    // Given
+    $outputInterface = $this
+      ->getMockBuilder(OutputInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $config = $this
+      ->getMockBuilder(Config::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $config->expects($this->once())->method('getImageDrivers')->willReturn([]);
+    $screenshotProvider = new ScreenshotProvider($outputInterface, $config, 1);
+    Allure::setDefaultLifecycle();
+    Provider::setOutputDirectory(null);
+
+    // When
+    $screenshotProvider->upload('test');
+
+    // Then
+    Assert::assertNull(Allure::lifecycle()->getLastEvent());
+  }
+}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31453

This PR:
1) Adds two attachments providers:
a) Screenshot provider, which fires when the https://github.com/elvetemedve/behat-screenshot extension triggers and adds a screenshot to Allure as well
b) Text attachments provider, which is executed after every step and in case of failure fires attachments with browser and applications logs.
2) Adds configuration option for maximum number of image attachments in a report
3) Formates the Scenario name displayed in reports (previously done in https://github.com/ezsystems/BehatBundle/pull/146)